### PR TITLE
post items and bitstreams

### DIFF
--- a/dsaps/cli.py
+++ b/dsaps/cli.py
@@ -86,21 +86,22 @@ def newcoll(ctx, comm_handle, coll_name, metadata, file_path, file_type,
             ingest_type):
     client = ctx.obj['client']
     start_time = ctx.obj['start_time']
-    coll_metadata = json.load(open(metadata))
-    coll_id = client.post_coll_to_comm(comm_handle, coll_name)
-    file_dict = {}
-    if ingest_type == 'local':
-        files = glob.glob(f'{file_path}/**/*.{file_type}', recursive=True)
-        for file in files:
-            file_name = os.path.basename(file).replace(f'.{file_type}', '')
-            file_dict[file_name] = file
-    elif ingest_type == 'remote':
-        file_dict = models.build_file_dict_remote(file_path, file_type,
-                                                  file_dict)
-    items = client.post_items_to_coll(coll_id, coll_metadata, file_dict,
-                                      ingest_type)
-    for item in items:
-        logger.info(f'Item posted: {item}')
+    with open(metadata, encoding='UTF-8') as fp:
+        coll_metadata = json.load(fp)
+        coll_id = client.post_coll_to_comm(comm_handle, coll_name)
+        file_dict = {}
+        if ingest_type == 'local':
+            files = glob.glob(f'{file_path}/**/*.{file_type}', recursive=True)
+            for file in files:
+                file_name = os.path.splitext(file)[0][file.rindex('/') + 1:]
+                file_dict[file_name] = file
+        elif ingest_type == 'remote':
+            file_dict = models.build_file_dict_remote(file_path, file_type,
+                                                      file_dict)
+        items = client.post_items_to_coll(coll_id, coll_metadata, file_dict,
+                                          ingest_type)
+        for item in items:
+            logger.info(f'Item posted: {item}')
     models.elapsed_time(start_time, 'Total runtime:')
 
 

--- a/dsaps/cli.py
+++ b/dsaps/cli.py
@@ -93,7 +93,7 @@ def newcoll(ctx, comm_handle, coll_name, metadata, file_path, file_type,
         if ingest_type == 'local':
             files = glob.glob(f'{file_path}/**/*.{file_type}', recursive=True)
             for file in files:
-                file_name = os.path.splitext(file)[0][file.rindex('/') + 1:]
+                file_name = os.path.splitext(os.path.basename(file))[0]
                 file_dict[file_name] = file
         elif ingest_type == 'remote':
             file_dict = models.build_file_dict_remote(file_path, file_type,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,16 @@ def client():
     return client
 
 
+@pytest.fixture
+def sample_content(tmp_path):
+    content = 'test'
+    dir = tmp_path / 'sub'
+    dir.mkdir()
+    sample_content = dir / '123.pdf'
+    sample_content.write_text(content)
+    return sample_content
+
+
 def test_authenticate(client):
     """Test authenticate function."""
     with requests_mock.Mocker() as m:
@@ -55,16 +65,56 @@ def test_filtered_item_search(client):
 
 
 def test_post_coll_to_comm(client):
+    """Test post_coll_to_comm function."""
     with requests_mock.Mocker() as m:
         comm_handle = '1234'
         coll_name = 'Test Collection'
         json_object_1 = {'uuid': 'a1b2'}
-        json_object_2 = {'link': '5678'}
+        json_object_2 = {'uuid': '5678'}
         m.get('mock://example.com/handle/1234', json=json_object_1)
         m.post('mock://example.com/communities/a1b2/collections',
                json=json_object_2)
         coll_id = client.post_coll_to_comm(comm_handle, coll_name)
         assert coll_id == '5678'
+
+
+def test_post_items_to_coll(client, sample_content):
+    """Test post_items_to_coll function."""
+    with requests_mock.Mocker() as m:
+        coll_metadata = [{"metadata": [
+                         {"key": "file_identifier",
+                          "value": "123"},
+                         {"key": "dc.title", "value":
+                          "Monitoring Works: Getting Teachers",
+                          "language": "en_US"}]}]
+        coll_id = '789'
+        ingest_type = 'local'
+        file_dict = {'123': sample_content}
+        json_object_1 = {'uuid': 'a1b2'}
+        m.post('mock://example.com/collections/789/items', json=json_object_1)
+        url = 'mock://example.com/items/a1b2/bitstreams?name=123.pdf'
+        json_object_2 = {'uuid': 'c3d4'}
+        m.post(url, json=json_object_2)
+        item_ids = client.post_items_to_coll(coll_id, coll_metadata, file_dict,
+                                             ingest_type)
+        for item_id in item_ids:
+            assert 'a1b2' == item_id
+
+
+def test_post_bitstreams_to_item(client, sample_content):
+    """Test post_bitstreams_to_item function."""
+    with requests_mock.Mocker() as m:
+        item_id = 'a1b2'
+        ingest_type = 'local'
+        file_identifier = '123'
+        file_dict = {'123': sample_content}
+        json_object_1 = {'uuid': 'c3d4'}
+        url = 'mock://example.com/items/a1b2/bitstreams?name=123.pdf'
+        m.post(url, json=json_object_1)
+        bit_ids = client.post_bitstreams_to_item(item_id, file_identifier,
+                                                 file_dict, ingest_type)
+        for bit_id in bit_ids:
+            assert 'c3d4' == bit_id
 
 
 def test__pop_inst(client):
@@ -84,8 +134,8 @@ def test__build_uuid_list(client):
     assert '1234' in child_list
 
 
-def test_build_file_list_remote():
-    """Test build_file_list_remote function."""
+def test_build_file_dict_remote():
+    """Test build_file_dict_remote function."""
     content = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>'
     content += '<head><title>Index of /pdf</title></head><body><h1>Index of /'
     content += 'pdf</h1><table><tr><th>Name</th><th>Last modified</th><th>'
@@ -93,8 +143,9 @@ def test_build_file_list_remote():
     content += '2001-02-16 11:59 </td><td>107K</td></tr></table></body></html>'
     with requests_mock.Mocker() as m:
         directory_url = 'mock://test.com/pdfs/'
-        file_extension = 'pdf'
+        file_type = 'pdf'
+        file_dict = {}
         m.get(directory_url, text=content)
-        file_list = models.build_file_list_remote(directory_url,
-                                                  file_extension)
-        assert '999.pdf' in file_list
+        file_list = models.build_file_dict_remote(directory_url, file_type,
+                                                  file_dict)
+        assert '999' in file_list


### PR DESCRIPTION
#### What does this PR do?
This PR adds methods to post items to collections and bitstreams to items. This ends up being a little complex since the bitstream method is nested under the item method (there isn't a use case where we would create an item without a corresponding bitstream). I've added a few click options as well. The results of a local ingest and a remote ingest can be viewed here https://mit-test.atmire.com/handle/1721.1/121959 I'm happy to provide more info about anything that is unclear. There are corresponding tests and a few minor edits to the build_remote_file_dict function and a few docstrings.

#### Includes new or updated dependencies?
YES
